### PR TITLE
Skip setting hash if hash was not set previously

### DIFF
--- a/src/package-fetcher.js
+++ b/src/package-fetcher.js
@@ -88,7 +88,11 @@ export default class PackageFetcher {
         newPkg = res.package;
 
         // update with new remote
-        ref.remote.hash = res.hash;
+        // but only if there was a hash previously as the tarball fetcher does not provide a hash.
+        if(ref.remote.hash) {
+          ref.remote.hash = res.hash;
+        }
+
         if (res.resolved) {
           ref.remote.resolved = res.resolved;
         }


### PR DESCRIPTION
**Summary**

This should fix https://github.com/yarnpkg/yarn/issues/1834 where yarn had resolved the host-git-packages without a hash and downloaded them to the cache folder <Packagename>-<Version>. The tarball fetcher would then add the hash after the download completed resulting in the linker believing that the Package could be found in the cache folder <Packagename>-<Version>-<Hash>.
**Test plan**

yarn add mulesoft/api-console.git#master would not work. Now works.

